### PR TITLE
Small fixes for old subtitles

### DIFF
--- a/src/parser/stream-parsers.ts
+++ b/src/parser/stream-parsers.ts
@@ -120,6 +120,7 @@ export class StreamParser {
 					break;
 
 				case "V4+ Styles":
+				case "V4 Styles":
 					if (this._ass.stylesFormatSpecifier === null) {
 						const property = parseLineIntoProperty(line);
 						if (property !== null && property.name === "Format") {

--- a/src/types/ass.ts
+++ b/src/types/ass.ts
@@ -163,8 +163,13 @@ export class ASS {
 			console.log(`Read dialogue: ${ repr }`);
 		}
 
-		// Create the dialogue and add it to the dialogues array
-		this.dialogues.push(new Dialogue(dialogueTemplate, this));
+		try {
+			// Create the dialogue and add it to the dialogues array
+			this.dialogues.push(new Dialogue(dialogueTemplate, this));
+		}
+		catch (e) {
+			console.log(e);
+		}
 	}
 
 	/**

--- a/src/types/dialogue.ts
+++ b/src/types/dialogue.ts
@@ -23,6 +23,8 @@ import { Style } from "./style";
 
 import { valueOrDefault } from "./misc";
 
+import { parseLineIntoTypedTemplate } from "../parser/misc";
+
 import { parse } from "../parser/parse";
 
 import * as parts from "../parts/index";
@@ -66,7 +68,12 @@ export class Dialogue {
 		const style = template.get("Style");
 		this._style = ass.styles.get(style);
 		if (this._style === undefined) {
-			throw new Error(`Unrecognized style ${ style }`);
+			this._style = ass.styles.get("Default");
+		}
+		if (this._style === undefined) {
+			let styleLine = parseLineIntoTypedTemplate("Style: Default,Open Sans Semibold,36,&H00FFFFFF,&H000000FF,&H00020713,&H00000000,-1,0,0,0,100,100,0,0,1,1.7,0,2,0,0,28,1", ["Name", "Fontname", "Fontsize", "PrimaryColour", "SecondaryColour", "OutlineColour", "BackColour", "Bold", "Italic", "Underline", "StrikeOut", "ScaleX", "ScaleY", "Spacing", "Angle", "BorderStyle", "Outline", "Shadow", "Alignment", "MarginL", "MarginR", "MarginV", "Encoding"]);
+			ass.styles.set("Default", new Style(styleLine.template));
+			this._style = ass.styles.get("Default");
 		}
 
 		this._start = Dialogue._toTime(template.get("Start"));


### PR DESCRIPTION
Hi.

I like to use libjass. Great work!

Here is small fixes that add ability to use old subtitles. By "old subtitles" I mean subtitles that use "V4 Styles", has missing styles, etc.

Some comments about changes:
1. Exception catching not very smart. Probably your tests would like to catch exceptions. In my variant exceptions just supressed and logged into console.
2. "Default" style parsed from string. That most simple way I found but it has cons. For example font size probably should depend on subtitle resolution (PlayResX/PlayResY) - in my variant font size just hardcoded.

As you see my "pull request" not so great, it more like feature request :-)