### PR TITLE
Add ability to change fallback fonts

### DIFF
--- a/src/renderers/settings.ts
+++ b/src/renderers/settings.ts
@@ -64,6 +64,17 @@ export class RendererSettings {
 	enableSvg: boolean;
 
 	/**
+	 * Comma-separated list of fonts to be used when font specified in ASS Styles not loaded.
+	 * 
+	 * Value should be a valid CSS font-family property (i.e. comma-separated and individual names in quotes if necessary).
+	 *
+	 * Defaults to 'Arial, Helvetica, sans-serif, "Segoe UI Symbol"'.
+	 *
+	 * @type {string}
+	 */
+	fallbackFonts: string;
+
+	/**
 	 * A convenience method to create a font map from a <style> or <link> element that contains @font-face rules. There should be one @font-face rule for each font name, mapping to a font file URL.
 	 *
 	 * For example:
@@ -115,12 +126,13 @@ export class RendererSettings {
 			object = {};
 		}
 
-		const { fontMap = null, preRenderTime = 5, preciseOutlines = false, enableSvg = true } = <RendererSettings>object;
+		const { fontMap = null, preRenderTime = 5, preciseOutlines = false, enableSvg = true, fallbackFonts = 'Arial, Helvetica, sans-serif, "Segoe UI Symbol"' } = <RendererSettings>object;
 		const result = new RendererSettings();
 		result.fontMap = fontMap;
 		result.preRenderTime = preRenderTime;
 		result.preciseOutlines = preciseOutlines;
 		result.enableSvg = enableSvg;
+		result.fallbackFonts = fallbackFonts;
 
 		return result;
 	}

--- a/src/renderers/web/renderer.ts
+++ b/src/renderers/web/renderer.ts
@@ -58,6 +58,8 @@ export class WebRenderer extends NullRenderer implements EventSource<string> {
 	private _layerWrappers: HTMLDivElement[] = [];
 	private _layerAlignmentWrappers: HTMLDivElement[][] = [];
 	private _fontSizeElement: HTMLDivElement;
+	
+	private _lineHeightsCache: Map<string, [number, number]> = new Map<string, [number, number]>();
 
 	private _currentSubs: Map<Dialogue, HTMLDivElement> = new Map<Dialogue, HTMLDivElement>();
 	private _preRenderedSubs: Map<number, PreRenderedSub> = new Map<number, PreRenderedSub>();
@@ -204,7 +206,7 @@ export class WebRenderer extends NullRenderer implements EventSource<string> {
 		svgElement.appendChild(svgDefsElement);
 
 		let currentSpan: HTMLSpanElement = null;
-		const currentSpanStyles = new SpanStyles(this, dialogue, this._scaleX, this._scaleY, this.settings, this._fontSizeElement, svgDefsElement);
+		const currentSpanStyles = new SpanStyles(this, dialogue, this._scaleX, this._scaleY, this.settings, this._fontSizeElement, svgDefsElement, this._lineHeightsCache);
 
 		let currentAnimationCollection: AnimationCollection = null;
 

--- a/src/renderers/web/span-styles.ts
+++ b/src/renderers/web/span-styles.ts
@@ -44,6 +44,7 @@ import { Map } from "../../utility/map";
  * @param {!libjass.renderers.RendererSettings} settings The renderer settings
  * @param {!HTMLDivElement} fontSizeElement A <div> element to measure font sizes with
  * @param {!SVGDefsElement} svgDefsElement An SVG <defs> element to append filter definitions to
+ * @param {!Map<string, [number, number]>} lineHeightsCache Line heights cache
  */
 export class SpanStyles {
 	private _id: string;
@@ -90,7 +91,7 @@ export class SpanStyles {
 
 	private _nextFilterId = 0;
 
-	constructor(renderer: WebRenderer, dialogue: Dialogue, private _scaleX: number, private _scaleY: number, private _settings: RendererSettings, private _fontSizeElement: HTMLDivElement, private _svgDefsElement: SVGDefsElement) {
+	constructor(renderer: WebRenderer, dialogue: Dialogue, private _scaleX: number, private _scaleY: number, private _settings: RendererSettings, private _fontSizeElement: HTMLDivElement, private _svgDefsElement: SVGDefsElement, private _lineHeightsCache: Map<string, [number, number]>) {
 		this._id = `${ renderer.id }-${ dialogue.id }`;
 		this._defaultStyle = dialogue.style;
 
@@ -167,9 +168,16 @@ export class SpanStyles {
 		else if (this._bold !== false) {
 			fontStyleOrWeight += this._bold + " ";
 		}
-		const fontSize = (this._scaleY * fontSizeForLineHeight(this._fontName, this._fontSize * (isTextOnlySpan ? this._fontScaleY : 1), this._fontSizeElement)).toFixed(3);
+		const fontSize = (this._scaleY * this.fontSizeForLineHeight(this._fontName, this._fontSize * (isTextOnlySpan ? this._fontScaleY : 1), this._fontSizeElement)).toFixed(3);
 		const lineHeight = (this._scaleY * this._fontSize).toFixed(3);
-		span.style.font = `${ fontStyleOrWeight }${ fontSize }px/${ lineHeight }px "${ this._fontName }"`;
+		
+		let fonts = `"${ this._fontName }"`;
+		if (this._settings.fallbackFonts != '')
+		{
+			fonts += `, ${ this._settings.fallbackFonts }`;
+		}
+		
+		span.style.font = `${ fontStyleOrWeight }${ fontSize }px/${ lineHeight }px ${ fonts }`;
 
 		let textDecoration = "";
 		if (this._underline) {
@@ -401,6 +409,45 @@ export class SpanStyles {
 		const result = document.createElement("br");
 		result.style.lineHeight = `${ (this._scaleY * this._fontSize).toFixed(3) }px`;
 		return result;
+	}
+	
+	/**
+	 * Uses linear interpolation to calculate the CSS font size that would give the specified line height for the specified font family.
+	 *
+	 * @param {string} fontFamily
+	 * @param {number} lineHeight
+	 * @param {!HTMLDivElement} fontSizeElement
+	 * @return {number}
+	 */
+	private fontSizeForLineHeight(fontFamily: string, lineHeight: number, fontSizeElement: HTMLDivElement): number {
+		let existingLineHeights = this._lineHeightsCache.get(fontFamily);
+		if (existingLineHeights === undefined) {
+			const lowerLineHeight = this.lineHeightForFontSize(fontFamily, 180, fontSizeElement);
+			const upperLineHeight = this.lineHeightForFontSize(fontFamily, 360, fontSizeElement);
+			existingLineHeights = [lowerLineHeight, (360 - 180) / (upperLineHeight - lowerLineHeight)];
+			this._lineHeightsCache.set(fontFamily, existingLineHeights);
+		}
+	
+		const [lowerLineHeight, factor] = existingLineHeights;
+	
+		return 180 + (lineHeight - lowerLineHeight) * factor;
+	}
+	
+	/**
+	 * @param {string} fontFamily
+	 * @param {number} fontSize
+	 * @param {!HTMLDivElement} fontSizeElement
+	 * @return {number}
+	 */
+	private lineHeightForFontSize(fontFamily: string, fontSize: number, fontSizeElement: HTMLDivElement): number {
+		let fonts = `"${ this._fontName }"`;
+		if (this._settings.fallbackFonts != '')
+		{
+			fonts += `, ${ this._settings.fallbackFonts }`;
+		}
+		fontSizeElement.style.fontFamily = fonts;
+		fontSizeElement.style.fontSize = `${ fontSize }px`;
+		return fontSizeElement.offsetHeight;
 	}
 
 	/**
@@ -845,40 +892,4 @@ export class SpanStyles {
 	}
 
 	private static _valueOrDefault = <T>(newValue: T, defaultValue: T): T => ((newValue !== null) ? newValue : defaultValue);
-}
-
-const lineHeightsCache = new Map<string, [number, number]>();
-
-/**
- * Uses linear interpolation to calculate the CSS font size that would give the specified line height for the specified font family.
- *
- * @param {string} fontFamily
- * @param {number} lineHeight
- * @param {!HTMLDivElement} fontSizeElement
- * @return {number}
- */
-function fontSizeForLineHeight(fontFamily: string, lineHeight: number, fontSizeElement: HTMLDivElement): number {
-	let existingLineHeights = lineHeightsCache.get(fontFamily);
-	if (existingLineHeights === undefined) {
-		const lowerLineHeight = lineHeightForFontSize(fontFamily, 180, fontSizeElement);
-		const upperLineHeight = lineHeightForFontSize(fontFamily, 360, fontSizeElement);
-		existingLineHeights = [lowerLineHeight, (360 - 180) / (upperLineHeight - lowerLineHeight)];
-		lineHeightsCache.set(fontFamily, existingLineHeights);
-	}
-
-	const [lowerLineHeight, factor] = existingLineHeights;
-
-	return 180 + (lineHeight - lowerLineHeight) * factor;
-}
-
-/**
- * @param {string} fontFamily
- * @param {number} fontSize
- * @param {!HTMLDivElement} fontSizeElement
- * @return {number}
- */
-function lineHeightForFontSize(fontFamily: string, fontSize: number, fontSizeElement: HTMLDivElement): number {
-	fontSizeElement.style.fontFamily = fontFamily;
-	fontSizeElement.style.fontSize = `${ fontSize }px`;
-	return fontSizeElement.offsetHeight;
 }


### PR DESCRIPTION
Add ability to change fallback fonts to be used when font from ASS Styles not loaded (for any reason).
Default fallback font is browser default font (for example Times New Roman in Google Chrome).

Though I don't know how to read this._settings.fallbackFonts from function lineHeightForFontSize. Of course there is no "this" in function. How to do it?