### PR TITLE
Add explicit line-height to .libjass-font-measure

### DIFF
--- a/lib/libjass.css
+++ b/lib/libjass.css
@@ -94,6 +94,7 @@
 	border: 0;
 	margin: 0;
 	padding: 0;
+	line-height: normal;
 }
 
 .libjass-filters {


### PR DESCRIPTION
Currently line-height for .libjass-font-measure determined by site css. For example if you run libjass on github.com then line-height for .libjass-font-measure would be 1.4. Of course that's not correct that line-height and font size in subtitles determined by site css.

I'm put "1.15" and not "normal" because:
> declaring line-height: normal not only vary from browser to browser, which I had expected—in fact, quantifying those differences was the whole point—but they also vary from one font face to another, and can also vary within a given face.

"1.15" looks similar to line-height used in libass/VSFilter. Maybe you know where in libass sources I can find real value of line-height?

BTW, if line-height is constant then maybe libjass-font-mesure is unnecessary? I mean if we know line-height then we can compute line-height and font-size without putting symbol in .libjass-font-measure.