### PR TITLE
Add getter for SpanStyles.outlineColor and SpanStyles.outlineColor

### DIFF
--- a/src/renderers/web/span-styles.ts
+++ b/src/renderers/web/span-styles.ts
@@ -802,12 +802,30 @@ export class SpanStyles {
 	}
 
 	/**
+	 * Gets the outline color property.
+	 *
+	 * @type {!libjass.Color}
+	 */
+	get outlineColor(): Color {
+		return this._outlineColor;
+	}
+
+	/**
 	 * Sets the outline color property. null defaults it to the default style's value.
 	 *
 	 * @type {libjass.Color}
 	 */
 	set outlineColor(value: Color) {
 		this._outlineColor = SpanStyles._valueOrDefault(value, this._defaultStyle.outlineColor);
+	}
+
+	/**
+	 * Gets the shadow color property.
+	 *
+	 * @type {!libjass.Color}
+	 */
+	get shadowColor(): Color {
+		return this._shadowColor;
 	}
 
 	/**


### PR DESCRIPTION
Getters for SpanStyles.outlineColor and SpanStyles.outlineColor are missing for some reason. This pull request fixes that.

For example exception would be thrown:
```
Uncaught TypeError: Cannot read property 'interpolate' of undefinedWebRenderer.preRender @ renderer.ts:552
```
on this script:
```
[Script Info]
Title:
ScriptType: v4.00+
WrapStyle: 0
PlayResX: 1280
PlayResY: 720
ScaledBorderAndShadow: yes

[V4+ Styles]
Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
Style: Default,Trebuchet MS,54,&H00FFFFFF,&H000000FF,&H00020713,&H00000000,-1,0,0,0,100,100,0,0,1,2.55,0,2,0,0,42,1

[Events]
Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
Dialogue: 0,0:00:00.00,0:00:03.00,Default,,0,0,0,,{\t(0,180,\3c&H0043FF&}test
```