### PR TITLE
Set radius attributes on SVGFEMorphologyElement via setAttribute

### DIFF
--- a/src/renderers/web/span-styles.ts
+++ b/src/renderers/web/span-styles.ts
@@ -362,8 +362,7 @@ export class SpanStyles {
 				filterElement.insertBefore(outlineFilter, mergedOutlines);
 				outlineFilter.in1.baseVal = "source";
 				outlineFilter.operator.baseVal = SVGFEMorphologyElement.SVG_MORPHOLOGY_OPERATOR_DILATE;
-				outlineFilter.radiusX.baseVal = x;
-				outlineFilter.radiusY.baseVal = y;
+				outlineFilter.setAttribute("radius", x + " " + y);
 				outlineFilter.result.baseVal = outlineId;
 
 				const outlineReferenceNode = document.createElementNS("http://www.w3.org/2000/svg", "feMergeNode");


### PR DESCRIPTION
Works around bug in Microsoft Edge where SVGFEMorphologyElement radiusX.baseVal and radiusY.baseVal cannot be set directly.
https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/6618301/

Demo of dynamically updating radius x and y properties using this method.
http://www.webpackbin.com/NkuWAxTNG