### PR TITLE
Soft line breaks breaking rendering of subititles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 /npm-debug.log
 
 /src/version.ts
+
+.idea

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -240,7 +240,7 @@ class ParserRun {
 	parse_newline(parent: ParseNode): ParseNode | null {
 		const current = new ParseNode(parent);
 
-		if (this.read(current, "\\N") === null) {
+		if (this.read(current, "\\N") === null && this.read(current, "\\n") === null) {
 			parent.pop();
 			return null;
 		}


### PR DESCRIPTION
In our application we sometimes get substation alpha authors that put the
string literal "\n" at the end of dialogue in addition to the whitepace `\n` 
that demarcates the new line of dialogue in the .SSA file.  Some also use
it in place of the hard line break, so that results in "\n" in the middle of a 
line of dialogue being rendered.

Since the Aegisub spec doesn't prevent the use of the soft line break:
http://docs.aegisub.org/3.2/ASS_Tags/#wrapstyle, we will add the literal 
"\n" to the tests for new line breaks in `parse.ts`

A lot of our developers use JetBrains products, so we added ".idea" to the 
.gitignore.